### PR TITLE
Feat: Sync Streams from Mediamtx to TAK Server

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "1.6.0+260513"
+current_version = "1.6.1+260523"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)\\+(?P<release>\\d+)"
 serialize = ["{major}.{minor}.{patch}+{release}"]
 search = "{current_version}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rmmtxauthz"
-version = "1.6.0+260513"
+version = "1.6.1+260523"
 description = "Do HTTP based authz for MediaMTX"
 authors = [{ name = "Eero af Heurlin", email = "eero.afheurlin@iki.fi" }]
 license = "MIT"

--- a/src/rmmtxauthz/__init__.py
+++ b/src/rmmtxauthz/__init__.py
@@ -1,3 +1,3 @@
 """Do HTTP based authz for MediaMTX"""
 
-__version__ = "1.6.0+260513"  # NOTE Use `bump-my-version` to bump versions correctly
+__version__ = "1.6.1+260523"  # NOTE Use `bump-my-version` to bump versions correctly

--- a/src/rmmtxauthz/mediamtx.py
+++ b/src/rmmtxauthz/mediamtx.py
@@ -105,3 +105,27 @@ class MediaMTXControl:
                     item["urls"][pname] = url  # type: ignore[index]
                 ret.append(item)
         return ret
+
+    async def get_active_paths(
+        self, username: str, password: str = ""
+    ) -> Sequence[Dict[str, Any]]:
+        """Return only ready MediaMTX paths."""
+        ret = []
+        async with self.get_session() as session:
+            resp = await session.get("/v3/paths/list", params={"itemsPerPage": 1000})
+            payload = await resp.json()
+        cnf = RMMTXSettings.singleton()
+        rtmps = cnf.protocols["rtmps"]
+        for plitem in payload["items"]:
+            if not bool(plitem.get("ready", plitem.get("sourceReady", True))):
+                continue
+            path = f"/{plitem['name']}"
+            ret.append(
+                {
+                    "path": path,
+                    "urls": {
+                        "rtmps": f"{rtmps.proto}://{cnf.mtx_address}:{rtmps.port}{path}?user={username}&pass={password}"
+                    },
+                }
+            )
+        return ret

--- a/src/rmmtxauthz/schema/interop.py
+++ b/src/rmmtxauthz/schema/interop.py
@@ -39,22 +39,49 @@ class ProductAuthzResponse(BaseModel):
         description="Password for read-only streaming", default=None
     )
 
+
+class ProductAuthzRequest(BaseModel):
+    """Brokered auth lookup request."""
+
+    certcn: str = Field(description="CN of the source product certificate")
+
     model_config = ConfigDict(
         extra="forbid",
         json_schema_extra={
             "examples": [
                 {
-                    "type": "mtls",
+                    "certcn": "product.deployment.tld",
                 },
+            ],
+        },
+    )
+
+
+class ProductStreamURLs(BaseModel):
+    """Protocol URLs for a product-visible stream."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    rtmps: Optional[str] = Field(default=None)
+
+
+class ProductStream(BaseModel):
+    """TAK-facing active stream inventory item."""
+
+    path: str = Field(description="MediaMTX path")
+    alias: str = Field(description="Human-readable stream alias")
+    urls: ProductStreamURLs
+
+    model_config = ConfigDict(
+        extra="forbid",
+        json_schema_extra={
+            "examples": [
                 {
-                    "type": "bearer-token",
-                    "token": "<JWT>",
-                },
-                {
-                    "type": "basic",
-                    "username": "product.deployment.tld",
-                    "password": "<PASSWORD>",
-                    "ro_password": "<PASSWORD>",
+                    "path": "/live/demo",
+                    "alias": "live/demo",
+                    "urls": {
+                        "rtmps": "rtmps://mtx.example.test:1936/live/demo?user=product.deployment.tld&pass=stream-ro-password",
+                    },
                 },
             ],
         },

--- a/src/rmmtxauthz/web/interop.py
+++ b/src/rmmtxauthz/web/interop.py
@@ -1,8 +1,11 @@
 """Routes for interoperation between products"""
 
+from typing import Sequence
 import logging
+import secrets
 
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, HTTPException, status
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from libpvarki.middleware import MTLSHeader
 from libpvarki.schemas.generic import OperationResultResponse
 
@@ -11,14 +14,43 @@ from .usercrud import comes_from_rm
 from ..db.product import Product
 from ..db.errors import NotFound
 from ..db.engine import EngineWrapper
-from ..schema.interop import ProductAddRequest, ProductAuthzResponse
+from ..schema.interop import (
+    ProductAddRequest,
+    ProductAuthzResponse,
+    ProductAuthzRequest,
+    ProductStream,
+    ProductStreamURLs,
+)
+from ..mediamtx import MediaMTXControl
 
 LOGGER = logging.getLogger(__name__)
 
-interoprouter = APIRouter(dependencies=[Depends(MTLSHeader(auto_error=True))])
+interoprouter = APIRouter()
+basic_auth = HTTPBasic(auto_error=True)
 
 
-@interoprouter.post("/add")
+async def get_product_from_basic(
+    credentials: HTTPBasicCredentials = Depends(basic_auth),
+) -> Product:
+    """Authenticate product inventory access with product basic auth."""
+    try:
+        product = await Product.by_cn(credentials.username)
+    except NotFound as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid product credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        ) from exc
+    if not secrets.compare_digest(credentials.password, product.mtxpassword):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid product credentials",
+            headers={"WWW-Authenticate": "Basic"},
+        )
+    return product
+
+
+@interoprouter.post("/add", dependencies=[Depends(MTLSHeader(auto_error=True))])
 async def add_product(
     product: ProductAddRequest,
     request: Request,
@@ -38,7 +70,7 @@ async def add_product(
     return result
 
 
-@interoprouter.get("/authz")
+@interoprouter.get("/authz", dependencies=[Depends(MTLSHeader(auto_error=True))])
 async def get_authz(
     request: Request,
 ) -> ProductAuthzResponse:
@@ -52,3 +84,38 @@ async def get_authz(
         ro_password=product.stream_ro_password,
     )
     return result
+
+
+@interoprouter.post("/authz", dependencies=[Depends(MTLSHeader(auto_error=True))])
+async def get_authz_for_product(
+    payload: ProductAuthzRequest,
+    request: Request,
+) -> ProductAuthzResponse:
+    """Get authz info for a source product via RM brokerage."""
+    comes_from_rm(request)
+    product = await Product.by_cn(payload.certcn)
+    return ProductAuthzResponse(
+        type="basic",
+        username=product.certcn,
+        password=product.mtxpassword,
+        ro_password=product.stream_ro_password,
+    )
+
+
+@interoprouter.get("/streams", response_model=list[ProductStream])
+async def get_product_streams(
+    product: Product = Depends(get_product_from_basic),
+) -> Sequence[ProductStream]:
+    """Get active stream inventory for TAK/product integrations."""
+    streams = await MediaMTXControl.singleton().get_active_paths(
+        username=product.certcn,
+        password=product.stream_ro_password,
+    )
+    return [
+        ProductStream(
+            path=item["path"],
+            alias=item["path"].lstrip("/"),
+            urls=ProductStreamURLs.model_validate({"rtmps": item["urls"].get("rtmps")}),
+        )
+        for item in sorted(streams, key=lambda item: item["path"])
+    ]

--- a/tests/test_interop.py
+++ b/tests/test_interop.py
@@ -1,35 +1,51 @@
 """Test the interop endpoints"""
 
+from base64 import b64encode
 import logging
 
 import pytest
 from fastapi.testclient import TestClient
 
-from rmmtxauthz.schema.interop import ProductAddRequest, ProductAuthzResponse
+from rmmtxauthz.mediamtx import MediaMTXControl
+from rmmtxauthz.schema.interop import (
+    ProductAddRequest,
+    ProductAuthzResponse,
+    ProductStream,
+)
 from rmmtxauthz.db.product import Product
 
 LOGGER = logging.getLogger(__name__)
+
+
+async def ensure_product(
+    testclient: TestClient, certcn: str = "fake.localmaeher.dev.pvarki.fi"
+) -> Product:
+    """Ensure a product exists for interop tests."""
+    req = ProductAddRequest(
+        certcn=certcn,
+        x509cert="-----BEGIN CERTIFICATE-----\\nMIIEwjCC...\\n-----END CERTIFICATE-----\\n",
+    )
+    resp = testclient.post("/api/v1/interop/add", json=req.model_dump())
+    assert resp.status_code == 200
+    return await Product.by_cn(certcn)
 
 
 @pytest.mark.asyncio
 async def test_add(dbinstance: None, testclient: TestClient) -> None:
     """Test adding of product"""
     _ = dbinstance
-    req = ProductAddRequest(
-        certcn="fake.localmaeher.dev.pvarki.fi",
-        x509cert="-----BEGIN CERTIFICATE-----\\nMIIEwjCC...\\n-----END CERTIFICATE-----\\n",
-    )
-    payload = req.model_dump()
-    resp = testclient.post("/api/v1/interop/add", json=payload)
-    assert resp.status_code == 200
+    await ensure_product(testclient)
     dbproduct = await Product.by_cn("fake.localmaeher.dev.pvarki.fi")
     assert dbproduct
 
 
 @pytest.mark.asyncio
-async def test_authz(dbinstance: None, product_testclient: TestClient) -> None:
+async def test_authz(
+    dbinstance: None, testclient: TestClient, product_testclient: TestClient
+) -> None:
     """Test adding of product"""
     _ = dbinstance
+    await ensure_product(testclient)
     resp = product_testclient.get("/api/v1/interop/authz")
     assert resp.status_code == 200
     parsed = ProductAuthzResponse.model_validate_json(resp.text)
@@ -37,3 +53,56 @@ async def test_authz(dbinstance: None, product_testclient: TestClient) -> None:
     assert parsed.type == "basic"
     assert parsed.username == "fake.localmaeher.dev.pvarki.fi"
     assert parsed.token is None
+
+
+@pytest.mark.asyncio
+async def test_brokered_authz(dbinstance: None, testclient: TestClient) -> None:
+    """RM can fetch authz for a source product."""
+    _ = dbinstance
+    product = await ensure_product(testclient)
+    resp = testclient.post("/api/v1/interop/authz", json={"certcn": product.certcn})
+    assert resp.status_code == 200
+    parsed = ProductAuthzResponse.model_validate_json(resp.text)
+    assert parsed.username == product.certcn
+    assert parsed.password == product.mtxpassword
+    assert parsed.ro_password == product.stream_ro_password
+
+
+@pytest.mark.asyncio
+async def test_stream_inventory(
+    dbinstance: None,
+    testclient: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Product inventory returns active streams with read-only watch URLs."""
+    _ = dbinstance
+    product = await ensure_product(testclient)
+
+    async def fake_get_active_paths(
+        self: MediaMTXControl, username: str, password: str = ""
+    ) -> list[dict[str, object]]:
+        assert username == product.certcn
+        assert password == product.stream_ro_password
+        return [
+            {
+                "path": "/live/demo",
+                "urls": {
+                    "rtmps": f"rtmps://streams.example.test:1936/live/demo?user={username}&pass={password}",
+                },
+            }
+        ]
+
+    monkeypatch.setattr(MediaMTXControl, "get_active_paths", fake_get_active_paths)
+    authz = b64encode(f"{product.certcn}:{product.mtxpassword}".encode("utf-8")).decode(
+        "ascii"
+    )
+    resp = testclient.get(
+        "/api/v1/interop/streams", headers={"Authorization": f"Basic {authz}"}
+    )
+    assert resp.status_code == 200
+    parsed = [ProductStream.model_validate(item) for item in resp.json()]
+    assert len(parsed) == 1
+    assert parsed[0].path == "/live/demo"
+    assert parsed[0].alias == "live/demo"
+    assert parsed[0].urls.rtmps
+    assert product.stream_ro_password in parsed[0].urls.rtmps

--- a/tests/test_rmmtxauthz.py
+++ b/tests/test_rmmtxauthz.py
@@ -6,7 +6,7 @@ from rmmtxauthz.config import RMMTXSettings
 
 def test_version() -> None:
     """Make sure version matches expected"""
-    assert __version__ == "1.6.0+260513"
+    assert __version__ == "1.6.1+260523"
 
 
 def test_config() -> None:

--- a/tests/test_userdirect.py
+++ b/tests/test_userdirect.py
@@ -6,6 +6,8 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from rmmtxauthz.mediamtx import MediaMTXControl
+
 from .test_mediamtx import valid_user  # noqa F401
 
 from rmmtxauthz.db.user import User
@@ -45,3 +47,38 @@ def test_credentials(user_testclient: TestClient, valid_user: User) -> None:  # 
     assert payload["username"] == valid_user.username
     assert payload["password"] == valid_user.mtxpassword
     assert payload["stream_ro_password"] == valid_user.stream_ro_password
+
+
+def test_streams(
+    user_testclient: TestClient,
+    valid_user: User,  # noqa: F811
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct stream inventory still uses the existing user-facing route shape."""
+
+    async def fake_get_paths(
+        self: MediaMTXControl, username: str, password: str = ""
+    ) -> list[dict[str, object]]:
+        assert username == valid_user.username
+        assert password == valid_user.mtxpassword
+        return [
+            {
+                "path": "/live/demo",
+                "urls": {
+                    "rtsps": f"rtsps://{username}:{password}@streams.example.test:8322/live/demo",
+                },
+            }
+        ]
+
+    monkeypatch.setattr(MediaMTXControl, "get_paths", fake_get_paths)
+    resp = user_testclient.get("/api/v1/direct/streams")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload == [
+        {
+            "path": "/live/demo",
+            "urls": {
+                "rtsps": f"rtsps://{valid_user.username}:{valid_user.mtxpassword}@streams.example.test:8322/live/demo",
+            },
+        }
+    ]


### PR DESCRIPTION
User-facing summary

 - Added TAK-facing active stream inventory to MediaMTX authz interop endpoints
 - Added RTMPS-only stream URL generation for TAK consumers
 - Improved product interop handling for automatic stream sync workflows

Why It's Good for the Product (Release Goal)

 - Makes active MediaMTX streams automatically available to TAK users
 - Reduces manual stream setup and credential sharing
 - Keeps TAK stream inventory aligned with live MediaMTX state

Any Other You'd Like to Mention

 - Supports the RM API -> MediaMTX -> TAK automatic sync flow
 - Focused on active stream discovery and TAK-compatible stream exposure